### PR TITLE
Fix clippy warning

### DIFF
--- a/src/backend/xoshiro256starstar.rs
+++ b/src/backend/xoshiro256starstar.rs
@@ -46,8 +46,8 @@ impl Xoshiro256StarStar {
         let mut state = SplitMix64::new(seed);
         let mut s = [0u64; 4];
 
-        for i in 0..4 {
-            s[i] = state.next_u64();
+        for x in s.iter_mut().take(4) {
+            *x = state.next_u64();
         }
 
         Self { s }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,6 @@ mod tests {
         assert!(val != 0);
 
         let float = rng.next_f64();
-        assert!(float >= 0.0 && float < 1.0);
+        assert!((0.0..1.0).contains(&float));
     }
 }


### PR DESCRIPTION
```rust
        // for i in 0..4 {
        //     s[i] = state.next_u64();
        // }
        for x in s.iter_mut().take(4) {
            *x = state.next_u64();
        }
```

```rust
        // assert!(float >= 0.0 && float < 1.0);
        assert!((0.0..1.0).contains(&float));
```